### PR TITLE
Handle offline user registration with queue

### DIFF
--- a/pos-frontend/src/App.jsx
+++ b/pos-frontend/src/App.jsx
@@ -12,6 +12,7 @@ import Header from "./components/shared/Header";
 import { useSelector } from "react-redux";
 import useLoadData from "./hooks/useLoadData";
 import FullScreenLoader from "./components/shared/FullScreenLoader";
+import useOfflineSync from "./hooks/useOfflineSync";
 
 function Layout() {
   const isLoading = useLoadData();
@@ -91,6 +92,7 @@ function ProtectedRoutes({ children }) {
 }
 
 function App() {
+  useOfflineSync();
   return (
     <Router>
       <Layout />

--- a/pos-frontend/src/components/auth/Register.jsx
+++ b/pos-frontend/src/components/auth/Register.jsx
@@ -2,6 +2,10 @@ import React, { useState } from "react";
 import { register } from "../../https";
 import { useMutation } from "@tanstack/react-query";
 import { enqueueSnackbar } from "notistack";
+import {
+  enqueueOfflineRequest,
+  OFFLINE_QUEUE_TYPES,
+} from "../../utils/offlineQueue";
 
 const Register = ({ setIsRegister }) => {
   const [formData, setFormData] = useState({
@@ -22,6 +26,25 @@ const Register = ({ setIsRegister }) => {
 
   const handleSubmit = (e) => {
     e.preventDefault();
+    const isOffline =
+      typeof navigator !== "undefined" && navigator.onLine === false;
+
+    if (isOffline) {
+      enqueueOfflineRequest(OFFLINE_QUEUE_TYPES.USER_REGISTRATION, formData);
+      enqueueSnackbar(
+        "Sin conexion. El registro se enviara automaticamente cuando vuelvas en linea.",
+        { variant: "info" }
+      );
+      setFormData({
+        name: "",
+        email: "",
+        phone: "",
+        password: "",
+        role: "",
+      });
+      return;
+    }
+
     registerMutation.mutate(formData);
   };
 

--- a/pos-frontend/src/hooks/useOfflineSync.js
+++ b/pos-frontend/src/hooks/useOfflineSync.js
@@ -1,0 +1,100 @@
+import { useEffect } from "react";
+import { enqueueSnackbar } from "notistack";
+import { register } from "../https";
+import {
+  getOfflineQueue,
+  removeOfflineEntries,
+  OFFLINE_QUEUE_TYPES,
+} from "../utils/offlineQueue";
+
+const buildResultMessage = (successCount, failureCount) => {
+  const parts = [];
+
+  if (successCount) {
+    parts.push(
+      `${successCount} registro${successCount > 1 ? "s" : ""} sincronizado${
+        successCount > 1 ? "s" : ""
+      } correctamente.`
+    );
+  }
+
+  if (failureCount) {
+    parts.push(
+      `${failureCount} registro${failureCount > 1 ? "s" : ""} no pudo sincronizarse.`
+    );
+  }
+
+  return parts.join(" ");
+};
+
+const useOfflineSync = () => {
+  useEffect(() => {
+    if (typeof window === "undefined") return undefined;
+
+    let isProcessing = false;
+
+    const syncRegistrations = async () => {
+      if (isProcessing) return;
+      isProcessing = true;
+
+      try {
+        const registrations = getOfflineQueue(
+          OFFLINE_QUEUE_TYPES.USER_REGISTRATION
+        );
+
+        if (!registrations.length) return;
+
+        const successfulIds = [];
+        let failedCount = 0;
+
+        for (const entry of registrations) {
+          try {
+            await register(entry.payload);
+            successfulIds.push(entry.id);
+          } catch {
+            failedCount += 1;
+          }
+        }
+
+        if (successfulIds.length) {
+          removeOfflineEntries(
+            OFFLINE_QUEUE_TYPES.USER_REGISTRATION,
+            successfulIds
+          );
+        }
+
+        if (successfulIds.length || failedCount) {
+          const variant = failedCount
+            ? successfulIds.length
+              ? "warning"
+              : "error"
+            : "success";
+
+          enqueueSnackbar(buildResultMessage(successfulIds.length, failedCount), {
+            variant,
+          });
+        }
+      } finally {
+        isProcessing = false;
+      }
+    };
+
+    const handleOnline = () => {
+      if (typeof navigator !== "undefined" && navigator.onLine) {
+        syncRegistrations();
+      }
+    };
+
+    window.addEventListener("online", handleOnline);
+
+    if (typeof navigator !== "undefined" && navigator.onLine) {
+      syncRegistrations();
+    }
+
+    return () => {
+      window.removeEventListener("online", handleOnline);
+    };
+  }, []);
+};
+
+export default useOfflineSync;

--- a/pos-frontend/src/utils/offlineQueue.js
+++ b/pos-frontend/src/utils/offlineQueue.js
@@ -1,0 +1,102 @@
+const STORAGE_PREFIX = "offlineQueue:";
+export const OFFLINE_QUEUE_TYPES = {
+  USER_REGISTRATION: "user-registration",
+};
+
+const isBrowser = () => typeof window !== "undefined" && !!window.localStorage;
+
+const getQueueKey = (type) => `${STORAGE_PREFIX}${type}`;
+
+const parseQueue = (value) => {
+  if (!value) return [];
+
+  try {
+    const parsed = JSON.parse(value);
+    if (!Array.isArray(parsed)) return [];
+
+    return parsed.filter((entry) => entry && typeof entry === "object" && entry.id);
+  } catch {
+    return [];
+  }
+};
+
+const readQueue = (type) => {
+  if (!isBrowser()) return [];
+
+  try {
+    const stored = window.localStorage.getItem(getQueueKey(type));
+    return parseQueue(stored);
+  } catch {
+    return [];
+  }
+};
+
+const writeQueue = (type, queue) => {
+  if (!isBrowser()) return;
+
+  const key = getQueueKey(type);
+
+  try {
+    if (!queue.length) {
+      window.localStorage.removeItem(key);
+      return;
+    }
+
+    window.localStorage.setItem(key, JSON.stringify(queue));
+  } catch {
+    /* empty */
+  }
+};
+
+const createQueueEntry = (type, payload) => ({
+  id: `${type}-${Date.now()}-${Math.random().toString(36).slice(2, 10)}`,
+  type,
+  payload,
+  createdAt: new Date().toISOString(),
+});
+
+export const enqueueOfflineRequest = (type, payload) => {
+  if (!type) return null;
+
+  const queue = readQueue(type);
+  const entry = createQueueEntry(type, payload);
+  queue.push(entry);
+  writeQueue(type, queue);
+  return entry;
+};
+
+export const getOfflineQueue = (type) => readQueue(type);
+
+export const removeOfflineEntries = (type, entryIds = []) => {
+  if (!entryIds || (Array.isArray(entryIds) && entryIds.length === 0)) return;
+
+  const ids = new Set(Array.isArray(entryIds) ? entryIds : [entryIds]);
+  const queue = readQueue(type);
+  const updatedQueue = queue.filter((entry) => !ids.has(entry.id));
+  writeQueue(type, updatedQueue);
+};
+
+export const clearOfflineQueue = (type) => {
+  if (!isBrowser()) return;
+
+  try {
+    window.localStorage.removeItem(getQueueKey(type));
+  } catch {
+    /* empty */
+  }
+};
+
+export const getAllOfflineEntries = () => {
+  if (!isBrowser()) return [];
+
+  try {
+    const entries = [];
+    Object.values(OFFLINE_QUEUE_TYPES).forEach((type) => {
+      const queue = readQueue(type);
+      entries.push(...queue);
+    });
+    return entries;
+  } catch {
+    return [];
+  }
+};


### PR DESCRIPTION
## Summary
- queue registration form submissions when the browser is offline instead of calling the API immediately
- add a reusable offline queue utility backed by localStorage for user registration requests
- process queued registrations when connectivity returns and notify the user about synchronization results

## Testing
- `npm run lint` *(fails: existing lint errors in unrelated files such as dashboard modals and constants)*

------
https://chatgpt.com/codex/tasks/task_e_68d11960c6a08330bf24a0b83147d0a3